### PR TITLE
Add two more compatibility methods with `time.Time{}`

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ There are several alternative date packages which cover wider date ranges.
 (These packages all use the [proleptic Gregorian calendar][6] to cover the
 historical date ranges.) Some existing packages:
 
+- `cloud.google.com/go/civil` [package][14]
 - `github.com/fxtlabs/date` [package][7]
 - `github.com/rickb777/date` [package][5]
 
@@ -240,3 +241,4 @@ doesn't implement a wider set of methods present on `time.Time{}` (e.g.
 [11]: https://pkg.go.dev/github.com/jackc/pgtype
 [12]: https://codecov.io/gh/hardfinhq/go-date/graph/badge.svg?token=MBWYQ3W2RM
 [13]: https://codecov.io/gh/hardfinhq/go-date
+[14]: https://pkg.go.dev/cloud.google.com/go/civil

--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ fmt.Println(d.ISOWeek())
 // 2020 9
 fmt.Println(d.Weekday())
 // Saturday
+fmt.Println(d.YearDay())
+// 60
+fmt.Println(d.Date())
+// 2020 February 29
 
 fmt.Println(d.IsZero())
 // false

--- a/date.go
+++ b/date.go
@@ -251,6 +251,14 @@ func (d Date) ToTime(opts ...ConvertOption) time.Time {
 	return time.Date(d.Year, d.Month, d.Day, cc.Hour, cc.Minute, cc.Second, cc.Nanosecond, cc.Timezone)
 }
 
+// Date returns the year, month, and day in which `d` occurs.
+//
+// This is here for parity with `time.Time{}.Date()` and is likely not
+// needed.
+func (d Date) Date() (int, time.Month, int) {
+	return d.Year, d.Month, d.Day
+}
+
 // ISOWeek returns the ISO 8601 year and week number in which `d` occurs.
 // Week ranges from 1 to 53. Jan 01 to Jan 03 of year `n` might belong to
 // week 52 or 53 of year `n-1`, and Dec 29 to Dec 31 might belong to week 1

--- a/date.go
+++ b/date.go
@@ -264,6 +264,12 @@ func (d Date) Weekday() time.Weekday {
 	return d.ToTime().Weekday()
 }
 
+// YearDay returns the day of the year specified by `d`, in the range [1,365]
+// for non-leap years, and [1,366] in leap years.
+func (d Date) YearDay() int {
+	return d.ToTime().YearDay()
+}
+
 // MarshalText implements the encoding.TextMarshaler interface.
 func (d Date) MarshalText() ([]byte, error) {
 	return []byte(d.String()), nil

--- a/date_test.go
+++ b/date_test.go
@@ -507,6 +507,37 @@ func TestDate_Weekday(base *testing.T) {
 	}
 }
 
+func TestDate_YearDay(base *testing.T) {
+	base.Parallel()
+
+	type testCase struct {
+		Date     date.Date
+		Expected int
+	}
+
+	cases := []testCase{
+		{Date: date.Date{Year: 2022, Month: time.December, Day: 31}, Expected: 365},
+		{Date: date.Date{Year: 2023, Month: time.January, Day: 1}, Expected: 1},
+		{Date: date.Date{Year: 2023, Month: time.January, Day: 5}, Expected: 5},
+		{Date: date.Date{Year: 2023, Month: time.January, Day: 6}, Expected: 6},
+		{Date: date.Date{Year: 2023, Month: time.January, Day: 8}, Expected: 8},
+		{Date: date.Date{Year: 2024, Month: time.December, Day: 31}, Expected: 366},
+	}
+
+	for i := range cases {
+		// NOTE: Assign to loop-local (instead of declaring the `tc` variable in
+		//       `range`) to avoid capturing reference to loop variable.
+		tc := cases[i]
+		base.Run(tc.Date.String(), func(t *testing.T) {
+			t.Parallel()
+			assert := testifyrequire.New(t)
+
+			yearDay := tc.Date.YearDay()
+			assert.Equal(tc.Expected, yearDay)
+		})
+	}
+}
+
 func TestDate_MarshalText(base *testing.T) {
 	base.Parallel()
 

--- a/date_test.go
+++ b/date_test.go
@@ -464,6 +464,17 @@ func TestDate_ToTime(t *testing.T) {
 	assert.Equal(expected, converted)
 }
 
+func TestDate_Date(t *testing.T) {
+	t.Parallel()
+	assert := testifyrequire.New(t)
+
+	d := date.Date{Year: 2006, Month: time.February, Day: 16}
+	year, month, day := d.Date()
+	assert.Equal(2006, year)
+	assert.Equal(time.February, month)
+	assert.Equal(16, day)
+}
+
 func TestDate_ISOWeek(t *testing.T) {
 	t.Parallel()
 	assert := testifyrequire.New(t)


### PR DESCRIPTION
Also mention https://pkg.go.dev/cloud.google.com/go/civil as an alternative