### PR TITLE
Allow empty location as no location info

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -115,11 +115,13 @@ func FromString(s string) (Date, error) {
 // FromTime validates that a `time.Time{}` contains a date and converts it to a
 // `Date{}`.
 func FromTime(t time.Time) (Date, error) {
+	hasLocationInfo := !(t.Location() == time.UTC || t.Location().String() == "")
+
 	if t.Hour() != 0 ||
 		t.Minute() != 0 ||
 		t.Second() != 0 ||
 		t.Nanosecond() != 0 ||
-		t.Location() != time.UTC {
+		hasLocationInfo {
 		return Date{}, fmt.Errorf("timestamp contains more than just date information; %s", t.Format(time.RFC3339Nano))
 	}
 

--- a/convert.go
+++ b/convert.go
@@ -115,7 +115,9 @@ func FromString(s string) (Date, error) {
 // FromTime validates that a `time.Time{}` contains a date and converts it to a
 // `Date{}`.
 func FromTime(t time.Time) (Date, error) {
-	hasLocationInfo := !(t.Location() == time.UTC || t.Location().String() == "")
+	zone, offset := t.Zone()
+
+	hasLocationInfo := !(t.Location() == time.UTC || (zone == "" && offset == 0))
 
 	if t.Hour() != 0 ||
 		t.Minute() != 0 ||

--- a/convert_test.go
+++ b/convert_test.go
@@ -103,12 +103,12 @@ func TestFromTime(base *testing.T) {
 		{
 			Time:     "2024-01-11T00:00:00.000-06:00",
 			Timezone: timezoneMetadata{Name: valueToPtr(""), Offset: valueToPtr(-21600)},
-			Error:    "timestamp contains more than just date information; 2024-01-11T00:00:00-06:00",
+			Date:     date.Date{Year: 2024, Month: time.January, Day: 11},
 		},
 		{
 			Time:     "2024-04-11T00:00:00.000-05:00",
 			Timezone: timezoneMetadata{Name: valueToPtr(""), Offset: valueToPtr(-18000)},
-			Error:    "timestamp contains more than just date information; 2024-04-11T00:00:00-05:00",
+			Date:     date.Date{Year: 2024, Month: time.April, Day: 11},
 		},
 		{
 			Time:     "2024-04-11T05:00:00.000Z",

--- a/convert_test.go
+++ b/convert_test.go
@@ -103,12 +103,12 @@ func TestFromTime(base *testing.T) {
 		{
 			Time:     "2024-01-11T00:00:00.000-06:00",
 			Timezone: timezoneMetadata{Name: valueToPtr(""), Offset: valueToPtr(-21600)},
-			Date:     date.Date{Year: 2024, Month: time.January, Day: 11},
+			Error:    "timestamp contains more than just date information; 2024-01-11T00:00:00-06:00",
 		},
 		{
 			Time:     "2024-04-11T00:00:00.000-05:00",
 			Timezone: timezoneMetadata{Name: valueToPtr(""), Offset: valueToPtr(-18000)},
-			Date:     date.Date{Year: 2024, Month: time.April, Day: 11},
+			Error:    "timestamp contains more than just date information; 2024-04-11T00:00:00-05:00",
 		},
 		{
 			Time:     "2024-04-11T05:00:00.000Z",


### PR DESCRIPTION

Package [github.com/lib/pq](https://github.com/lib/pq) converts Postgres type "Date" to `time.Time` with zero value location, not `nil`.
So, scanning it by `date.Date` returns error.

However I believe this is an issue on `github.com/lib/pq`, we can add this patch to `date.Date`.

Regarding the nil location, golang itself already handles this and returns UTC.