### PR TITLE
Skip caching for `golangci-lint-action`.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,6 +57,7 @@ jobs:
         uses: golangci/golangci-lint-action@3cfe3a4abbb849e10058ce4af15d205b6da42804 # v4.0.0
         with:
           version: v1.56.1
+          skip-cache: "true"
           args: "--verbose --timeout=2m"
 
       - name: Upload coverage reports to Codecov


### PR DESCRIPTION
See e.g. https://github.com/hardfinhq/go-date/actions/runs/8777802473/job/24083280197 where "Post golangci-lint" took 2m13s

The overhead doesn't appear to be worth it.

Note that both checks in this PR pass in 31s and 38s with no caching.